### PR TITLE
Fix typo preventing `UITableView` animations

### DIFF
--- a/Recordings-MVC/Recordings/FolderViewController.swift
+++ b/Recordings-MVC/Recordings/FolderViewController.swift
@@ -39,8 +39,8 @@ class FolderViewController: UITableViewController {
 		
 		// Handle changes to contents
 		if let changeReason = userInfo[Item.changeReasonKey] as? String {
-			let oldValue = userInfo[Item.newValueKey]
-			let newValue = userInfo[Item.oldValueKey]
+			let newValue = userInfo[Item.newValueKey]
+			let oldValue = userInfo[Item.oldValueKey]
 			switch (changeReason, newValue, oldValue) {
 			case let (Item.removed, _, (oldIndex as Int)?):
 				tableView.deleteRows(at: [IndexPath(row: oldIndex, section: 0)], with: .right)


### PR DESCRIPTION
In the `switch` below, `deleteRows()` or `insertRows` was not reached because of this typo. 

```
switch (changeReason, newValue, oldValue) {
case let (Item.removed, _, (oldIndex as Int)?):
	tableView.deleteRows(at: [IndexPath(row: oldIndex, section: 0)], with: .automatic)
case let (Item.added, (newIndex as Int)?, _):
	tableView.insertRows(at: [IndexPath(row: newIndex, section: 0)], with: .automatic)
case let (Item.renamed, (newIndex as Int)?, (oldIndex as Int)?):
	tableView.moveRow(at: IndexPath(row: oldIndex, section: 0), to: IndexPath(row: newIndex, section: 0))
	tableView.reloadRows(at: [IndexPath(row: newIndex, section: 0)], with: .automatic)
default:
	tableView.reloadData()
}
```