### PR TITLE
Fix crash due to inconsistency between the data source and the UITableView update

### DIFF
--- a/Recordings-controller-owned-networking/RecordingsClient/FolderViewController.swift
+++ b/Recordings-controller-owned-networking/RecordingsClient/FolderViewController.swift
@@ -148,8 +148,10 @@ class FolderViewController: UITableViewController, RecordViewControllerDelegate 
 	}
 	
 	func insert(item: Item) {
+		self.tableView.beginUpdates()
 		self.folder.contents.append(item)
 		self.tableView.insertRows(at: [IndexPath(row: self.folder.contents.endIndex-1, section: 0)], with: .automatic)
+		self.tableView.endUpdates()
 	}
 	
 	override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {


### PR DESCRIPTION
This PR addresses a critical issue where the app crashes when the user attempts to add a new record or create a new table. The crash occurs because of an inconsistency between the data source and the UITableView during batch updates.

<img width="870" alt="Screenshot 2024-08-12 at 13 00 49" src="https://github.com/user-attachments/assets/9c7d1160-742a-49bb-aceb-03e048a0e69a">
